### PR TITLE
Removing of "fi" and "fl" ligatures from the generated font

### DIFF
--- a/ligaturize.py
+++ b/ligaturize.py
@@ -287,6 +287,11 @@ def ligaturize_font(input_font_file, output_dir, ligature_font_file,
         output_font_type = '.otf'
     else:
         output_font_type = '.ttf'
+        
+    # Remove 'fi' and 'fl' glyphs
+    print ('Removing fi and fl ligatures...')
+    font.removeGlyph(0xFB01)
+    font.removeGlyph(0xFB02)
 
     # Generate font & move to output directory
     output_font_file = path.join(output_dir, font.fontname + output_font_type)


### PR DESCRIPTION
These ligatures are unwanted and make the code look crippled in VSCode with ligatures enabled:

<img width="477" alt="screen shot 2019-01-12 at 00 14 16" src="https://user-images.githubusercontent.com/1707/51060642-72e68880-1601-11e9-9a47-1dc1d98f86bd.png">

Fortunately, it is quite easy to remove them from the generated font.