### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:hirsute
+WORKDIR /Ligaturizer
+
+RUN apt-get update
+RUN apt-get -y install make
+RUN apt-get -y install python3-fontforge
+
+COPY ligatures.py ligatures.py
+COPY ligaturize.py ligaturize.py
+COPY build.py build.py
+COPY stat.py stat.py
+COPY char_dict.py char_dict.py
+
+COPY fonts/fira/distr/otf fonts/fira/distr/otf
+COPY fonts/input fonts/input
+COPY fonts/output fonts/output
+
+COPY Makefile Makefile
+
+ENTRYPOINT make


### PR DESCRIPTION
Dockerfiles make it easy for people who can't/didn't install `FontForge` on their computer (like me) but instead have docker.

To use this docker file, edit the `build.py`, build the docker image with `docker build . -t ligaturizer` and run it like so:
```
docker run --name ligma ligaturizer
mkdir container
docker export ligma > container/container.tar
cd container
tar xf container.tar
cp -r Ligaturizer/fonts/output ../fonts
cd ..
rm -rf container
docker rm ligma
```

What this does is generate the fonts and put them in the `fonts/output` folder